### PR TITLE
Detect and kill zombie tunnel

### DIFF
--- a/lib/supervise.js
+++ b/lib/supervise.js
@@ -44,7 +44,6 @@ let supervisor = new Supervisor({
 });
 
 let exitProcess = once((signal) => {
-  logger.log("==========================================================");
   logger.warn("Received " + signal + ". Stopping all Sauce Tunnels and Existing.");
 
   supervisor

--- a/lib/supervise.js
+++ b/lib/supervise.js
@@ -44,6 +44,7 @@ let supervisor = new Supervisor({
 });
 
 let exitProcess = once((signal) => {
+  logger.log("==========================================================");
   logger.warn("Received " + signal + ". Stopping all Sauce Tunnels and Existing.");
 
   supervisor

--- a/lib/supervise.js
+++ b/lib/supervise.js
@@ -55,7 +55,7 @@ Promise
   .delay(500)
   .then(() => supervisor.stage())
   .then(() => supervisor.startTunnels())
-  .then(() => {
+  .finally(() => {
     process.on("SIGINT", () => exitProcess("SIGINT"));
     process.on("SIGTERM", () => exitProcess("SIGTERM"));
 

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -27,8 +27,11 @@ export default class Supervisor {
   stage() {
     return new Promise((resolve, reject) => {
       // download sauce tunnel if necessary
-
+      logger.log("/*************************************************/");
       logger.log(util.format("Preparing %d Sauce Tunnel(s)", this.tunnelAmount));
+      logger.log(util.format("Rolling restart is enabled with schedule: %s", this.restartCron));
+      logger.log("/*************************************************/");
+
       for (let i = 0; i < this.tunnelAmount; i++) {
         this.tunnels.push(new Tunnel(_.extend(this.tunnelConfig, {
           id: i + 1,
@@ -56,8 +59,10 @@ export default class Supervisor {
       Promise
         .map(this.tunnels, (tunnel) => tunnel.start())
         .then(() => {
-          logger.log("All Sauce Tunnels have been successfully started" +
-            ", all failover Sauce Tunnels would be automatically restarted");
+          logger.log("/*************************************************/");
+          logger.log("All Sauce Tunnels have been successfully started");
+          logger.log("All failover Sauce Tunnels would be automatically restarted");
+          logger.log("/*************************************************/");
           resolve();
         })
         .catch((err) => {
@@ -72,7 +77,9 @@ export default class Supervisor {
       Promise
         .map(this.tunnels, (tunnel) => tunnel.stop())
         .then(() => {
+          logger.log("/*************************************************/");
           logger.log("All Sauce Tunnels have been successfully stopped");
+          logger.log("/*************************************************/");
           resolve();
         })
         .catch((err) => {
@@ -99,14 +106,20 @@ export default class Supervisor {
   scheduleRestart() {
     // restart all tunnels
     schedule.scheduleJob(this.restartCron, () => {
+      logger.log("/-------------------------------------------------/");
       logger.log(util.format("<restarting...> all %s Sauce Tunnels", this.tunnelAmount));
+      logger.log("/-------------------------------------------------/");
 
       Promise
         .map(this.tunnels, (tunnel) => tunnel.restart(), {
           // to make sure we rolling restart tunnels one by one 
           concurrency: 1
         })
-        .then(() => logger.log(util.format("<restarted> all %s Sauce Tunnels", this.tunnelAmount)))
+        .then(() => {
+          logger.log("/-------------------------------------------------/");
+          logger.log(util.format("<restarted> all %s Sauce Tunnels", this.tunnelAmount))
+          logger.log("/-------------------------------------------------/");
+        })
         .catch((err) => logger.err(util.format("Some tunnels failed in restart, they'll be restart in next try\n%s", err)));
     });
   }

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -69,7 +69,7 @@ export default class Supervisor {
 
   stopTunnels() {
     return new Promise((resolve, reject) => {
-
+      logger.log("==========================================================");
       Promise
         .map(this.tunnels, (tunnel) => tunnel.stop(true))
         .then(() => {
@@ -97,18 +97,19 @@ export default class Supervisor {
     });
   }
 
-  scheduleRestart() { 
+  scheduleRestart() {
     // restart all tunnels
     schedule.scheduleJob(this.restartCron, () => {
-      logger.log(util.format("Restarting all %s Sauce Tunnels", this.tunnelAmount));
+      logger.log("==========================================================");
+      logger.log(util.format("<restarting...> all %s Sauce Tunnels", this.tunnelAmount));
 
       Promise
         .map(this.tunnels, (tunnel) => tunnel.restart(), {
           // to make sure we rolling restart tunnels one by one 
           concurrency: 1
         })
-        .then(() => logger.log("All Sauce Tunnels have been successfully restarted"))
-        .catch((err) => logger.err(util.format("Some tunnels are wrong\n%s", err)));
+        .then(() => logger.log(util.format("<restarted> all %s Sauce Tunnels", this.tunnelAmount)))
+        .catch((err) => logger.err(util.format("Some tunnels failed in restart, they'll be restart in next try\n%s", err)));
     });
   }
 };

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -7,7 +7,7 @@ import _ from "lodash";
 import fs from "fs";
 import schedule from "node-schedule";
 
-import Tunnel from "./tunnel";
+import { STATE, Tunnel } from "./tunnel";
 import logger from "./logger";
 
 const PORT_BEGIN = 4000;
@@ -64,7 +64,8 @@ export default class Supervisor {
           logger.log("All failover Sauce Tunnels would be automatically restarted");
           logger.log("/*************************************************/");
           resolve();
-        }, (err) => {
+        })
+        .catch((err) => {
           logger.warn("/*************************************************/");
           logger.warn("Some tunnels failed in starting", err);
           logger.warn("All failover Sauce Tunnels would be automatically restarted in next rolling restart");
@@ -77,13 +78,14 @@ export default class Supervisor {
   stopTunnels() {
     return new Promise((resolve, reject) => {
       Promise
-        .map(this.tunnels, (tunnel) => tunnel.stop())
+        .map(this.tunnels, (tunnel) => tunnel.stop(STATE.QUITTING))
         .then(() => {
           logger.log("/*************************************************/");
           logger.log("All Sauce Tunnels have been successfully stopped");
           logger.log("/*************************************************/");
           resolve();
-        }, (err) => {
+        })
+        .catch((err) => {
           logger.err("Some tunnels failed in stopping", err);
           reject(err);
         })
@@ -121,7 +123,8 @@ export default class Supervisor {
           logger.log(util.format("<restarted> all %s Sauce Tunnels", this.tunnelAmount))
           logger.log("/-------------------------------------------------/");
           return Promise.resolve();
-        }, (err) => {
+        })
+        .catch((err) => {
           logger.warn("/-------------------------------------------------/");
           logger.warn("<restarted> Some tunnels failed in restart");
           logger.err(err)

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -66,7 +66,10 @@ export default class Supervisor {
           resolve();
         })
         .catch((err) => {
-          logger.err("Some tunnels failed in starting", err);
+          logger.warn("/*************************************************/");
+          logger.warn("Some tunnels failed in starting", err);
+          logger.warn("All failover Sauce Tunnels would be automatically restarted in next rolling restart round");
+          logger.warn("/*************************************************/");
           reject(err);
         });
     });
@@ -81,11 +84,10 @@ export default class Supervisor {
           logger.log("All Sauce Tunnels have been successfully stopped");
           logger.log("/*************************************************/");
           resolve();
-        })
-        .catch((err) => {
+        }, (err) => {
           logger.err("Some tunnels failed in stopping", err);
           reject(err);
-        });
+        })
     });
   }
 
@@ -119,8 +121,13 @@ export default class Supervisor {
           logger.log("/-------------------------------------------------/");
           logger.log(util.format("<restarted> all %s Sauce Tunnels", this.tunnelAmount))
           logger.log("/-------------------------------------------------/");
-        })
-        .catch((err) => logger.err(util.format("Some tunnels failed in restart, they'll be restart in next try\n%s", err)));
+          return Promise.resolve();
+        }, (err) => {
+          logger.warn("/-------------------------------------------------/");
+          logger.warn(util.format("Some tunnels failed in restart, they'll be restart in next rolling restart schedule\n%s", err));
+          logger.warn("/-------------------------------------------------/");
+          return Promise.resolve();
+        });
     });
   }
 };

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -69,15 +69,14 @@ export default class Supervisor {
 
   stopTunnels() {
     return new Promise((resolve, reject) => {
-      logger.log("==========================================================");
       Promise
-        .map(this.tunnels, (tunnel) => tunnel.stop(true))
+        .map(this.tunnels, (tunnel) => tunnel.stop())
         .then(() => {
           logger.log("All Sauce Tunnels have been successfully stopped");
           resolve();
         })
         .catch((err) => {
-          logger.err("Some tunnels failed in starting", err);
+          logger.err("Some tunnels failed in stopping", err);
           reject(err);
         });
     });
@@ -100,7 +99,6 @@ export default class Supervisor {
   scheduleRestart() {
     // restart all tunnels
     schedule.scheduleJob(this.restartCron, () => {
-      logger.log("==========================================================");
       logger.log(util.format("<restarting...> all %s Sauce Tunnels", this.tunnelAmount));
 
       Promise

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -64,11 +64,10 @@ export default class Supervisor {
           logger.log("All failover Sauce Tunnels would be automatically restarted");
           logger.log("/*************************************************/");
           resolve();
-        })
-        .catch((err) => {
+        }, (err) => {
           logger.warn("/*************************************************/");
           logger.warn("Some tunnels failed in starting", err);
-          logger.warn("All failover Sauce Tunnels would be automatically restarted in next rolling restart round");
+          logger.warn("All failover Sauce Tunnels would be automatically restarted in next rolling restart");
           logger.warn("/*************************************************/");
           reject(err);
         });
@@ -124,7 +123,9 @@ export default class Supervisor {
           return Promise.resolve();
         }, (err) => {
           logger.warn("/-------------------------------------------------/");
-          logger.warn(util.format("Some tunnels failed in restart, they'll be restart in next rolling restart schedule\n%s", err));
+          logger.warn("<restarted> Some tunnels failed in restart");
+          logger.err(err)
+          logger.warn("They will be restarted in next rolling restart schedule")
           logger.warn("/-------------------------------------------------/");
           return Promise.resolve();
         });

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -21,13 +21,13 @@ const RETRY_LIMIT = 10;
 const TUNNEL_STOP_TIMEOUT = 480000;
 const TUNNEL_START_TIMEOUT = 480000;
 
-const STATE = {
-  IDLE: 0, STARTING: 1, RUNNING: 2, STOPPING: 3
+export const STATE = {
+  IDLE: 0, STARTING: 1, RUNNING: 2, STOPPING: 3, QUITTING: 4
 };
 
 Promise.config({ cancellation: true });
 
-export default class Tunnel {
+export class Tunnel {
   constructor(options) {
     this.state = STATE.IDLE;
     this.retried = 0;
@@ -86,7 +86,7 @@ export default class Tunnel {
 
           } else {
             self.tunnelProcess = sauceConnectProcess;
-            logger.log(util.format("<started> Sauce Tunnel #%s", self.index));
+            logger.log(util.format("<started> Sauce Tunnel #%s (%s)", self.index, self.tunnelProcess.tunnelId));
             self.state = STATE.RUNNING;
             resolve();
           }
@@ -103,22 +103,22 @@ export default class Tunnel {
               self.index,
               moment.duration(TUNNEL_START_TIMEOUT).humanize())));
         })
-        .then(() => Promise.resolve(), (err) => {
-          return Promise.reject(err)
-        })
+        .then(() => Promise.resolve())
+        .catch((err) => Promise.reject(err));
 
     }
   }
 
-  stop() {
+  stop(currentState = STATE.STOPPING) {
     let self = this;
 
     if (self.state === STATE.IDLE
-      || self.state === STATE.STOPPING) {
+      || self.state === STATE.STOPPING
+      || self.state === STATE.QUITTING) {
       // dont do anything here
       return Promise.resolve();
     } else {
-      self.state = STATE.STOPPING;
+      self.state = currentState;
 
       let timeout = setTimeout(() => p.cancel(), TUNNEL_STOP_TIMEOUT);
       let p = new Promise((resolve, reject, onCancel) => {
@@ -166,7 +166,9 @@ export default class Tunnel {
 
     if (!isTimeout || !self.tunnelProcess) {
       // _handle is null, tunnel is terminated correctly, or tunnel child_process is set to be null
-      self.state = STATE.IDLE;
+      if (self.state !== STATE.QUITTING) {
+        self.state = STATE.IDLE;
+      }
       return Promise.resolve();
 
     } else {
@@ -209,11 +211,15 @@ export default class Tunnel {
               self.index,
               moment.duration(TUNNEL_STOP_TIMEOUT).humanize())));
         })
-        .then(() => self.start(), (err) => Promise.reject(err))
+        .then(() => self.start())
+        // propagate error
+        .catch((err) => Promise.reject(err))
         .then(() => {
           self.state = STATE.RUNNING;
           return Promise.resolve();
-        }, (err) => {
+        })
+        // propagate error
+        .catch((err) => {
           logger.warn(util.format("Sauce Tunnel #%s failled in restarting", self.index));
           logger.err(util.format("%s", err));
           return Promise.reject(err);
@@ -234,7 +240,8 @@ export default class Tunnel {
         self.retried = 0;
         if ((self.tunnelProcess && self.tunnelProcess["_handle"])
           || self.state === STATE.STOPPING
-          || self.state === STATE.STARTING) {
+          || self.state === STATE.STARTING
+          || self.state === STATE.QUITTING) {
           //child process is still alive
           return Promise
             .delay(MONITOR_INTERVAL)

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -61,11 +61,14 @@ export default class Tunnel {
           logger.err(util.format("Sauce Tunnel #%s times out while starting", self.index));
         });
 
+        logger.log(util.format("<starting...> Sauce Tunnel #%s", self.index));
+
         sauceConnectLauncher(self.options, (err, sauceConnectProcess) => {
           if (err) {
             logger.err(util.format("Error in starting Sauce Tunnel #%s \n %s", self.index, err));
             // retry it 
             if (self.retried < RETRY_LIMIT) {
+              logger.warn(util.format("<retried %s/%s starting...> Sauce Tunnel #%s still isn't started", self.retried + 1, RETRY_LIMIT, self.index));
               self.retried += 1;
               self.state = STATE.IDLE;
 
@@ -74,7 +77,7 @@ export default class Tunnel {
                 .then(() => {
                   self.state = STATE.RUNNING;
                   resolve();
-                });
+                }, (err) => Promise.reject(err));
             } else {
               self.state = STATE.IDLE;
               logger.err(util.format("Error in starting Sauce Tunnel #%s \n %s", self.index, err));
@@ -93,21 +96,17 @@ export default class Tunnel {
       return Promise
         // to avoid the blast of all tunnels launch up at same time  
         .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-        .then(() => {
-          logger.log(util.format("<starting...> Sauce Tunnel #%s", self.index));
-
-
-          return p;
+        .then(() => p)
+        .catch(Promise.CancellationError, (err) => {
+          return new Promise.reject(
+            new Promise.TimeoutError(util.format("Sauce Tunnel #%s isn't started in %s!",
+              self.index,
+              moment.duration(TUNNEL_START_TIMEOUT).humanize())));
         })
-        .finally(() => {
-          clearTimeout(timeout);
-          this.retried = 0;
-          if (p.isCancelled()) {
-            return Promise.reject();
-          } else {
-            return Promise.resolve();
-          }
-        });
+        .then(() => Promise.resolve(), (err) => {
+          return Promise.reject(err)
+        })
+
     }
   }
 
@@ -120,6 +119,7 @@ export default class Tunnel {
       return Promise.resolve();
     } else {
       self.state = STATE.STOPPING;
+
       let timeout = setTimeout(() => p.cancel(), TUNNEL_STOP_TIMEOUT);
       let p = new Promise((resolve, reject, onCancel) => {
 
@@ -171,9 +171,7 @@ export default class Tunnel {
 
     } else {
       // something happened to stop current tunnel from being terminated
-      logger.warn(util.format("<killing with SIGKILL...> Sauce Tunnel #%s doesn't terminate in %s!",
-        self.index,
-        moment.duration(TUNNEL_STOP_TIMEOUT).humanize()));
+      logger.warn(util.format("<killing with SIGKILL...> Sauce Tunnel #%s", self.index));
 
       return new Promise((resolve, reject) => {
         treeKill(self.tunnelProcess.pid, "SIGKILL", (err) => {
@@ -202,17 +200,22 @@ export default class Tunnel {
 
       return Promise
         .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-        .then(() => {
-          return self.stop()
+        .then(() => self.stop())
+        .catch(Promise.CancellationError, (err) => {
+          // start is skipped if a tunnel times out in stopping.
+          // it will be restarted in next scheduled restart
+          return Promise.reject(
+            new Promise.TimeoutError(util.format("Sauce Tunnel #%s isn't stopped in %s!",
+              self.index,
+              moment.duration(TUNNEL_STOP_TIMEOUT).humanize())));
         })
-        .then(() => {
-          return self.start()
-        })
+        .then(() => self.start(), (err) => Promise.reject(err))
         .then(() => {
           self.state = STATE.RUNNING;
           return Promise.resolve();
         }, (err) => {
-          logger.warn(util.format("Sauce Tunnel #%s failled in restarting, waiting for next rolling restart schedule\n%s", self.index, err));
+          logger.warn(util.format("Sauce Tunnel #%s failled in restarting", self.index));
+          logger.err(util.format("%s", err));
           return Promise.reject(err);
         });
     } else {

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -1,122 +1,217 @@
 "use strict";
 
 import sauceConnectLauncher from "sauce-connect-launcher";
+import treeKill from "tree-kill";
 import Promise from "bluebird";
 import _ from "lodash";
 import path from "path";
 import util from "util";
+import moment from "moment";
 
 import logger from "./logger";
 
 const privateOptions = Array.of("id", "pidTempPath", "restartCron");
 
-// check if tunnel is alive every 10 seconds
-const MONITOR_INTERVAL = 10;
+// frequency to check if a tunnel is alive in millisecond
+const MONITOR_INTERVAL = 10000;
 const DELAY_INTERVAL = 5000;
+// maximum retry times before a tunnel goes alive in millisecond
 const RETRY_LIMIT = 10;
+// maximum duration for a live tunnel in millisecond
+const MAX_ALIVE_DURATION = 300000;
 
 export default class Tunnel {
   constructor(options) {
     this.isSkippingMonitor = false;
+    this.isRestarting = false;
     this.retried = 0;
 
     this.tunnelProcess = null;
-    this.tunnelId = options.id;
+    this.index = options.id;
     this.pidTempPath = options.pidTempPath;
+    this.initStopAt = null;
 
     this.options = _.omit(options, privateOptions);
     // add individual info per tunnel
-    this.options.readyFileId = this.tunnelId.toString();
-    this.options.pidfile = path.resolve(this.pidTempPath, this.tunnelId.toString() + ".pid");
+    this.options.readyFileId = this.index.toString();
+    this.options.pidfile = path.resolve(this.pidTempPath, this.index.toString() + ".pid");
   }
 
   start() {
     let self = this;
-    // restarting
-    self.tunnelProcess = null;
 
-    return new Promise((resolve, reject) => {
-      return Promise
-        // to avoid the blast of all tunnels launch up at same time 
-        .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-        .then(() => {
-          logger.log(util.format("Starting Sauce Tunnel #%s, please be patient...", self.tunnelId));
+    if (self.initStopAt) {
+      // a this.stop method is called somewhere, we do stop first. we'll restart the tunnel in next scheduled time slot
+      logger.warn(util.format("Sauce Tunnel #%s recieves a stop call while restarting, postpone restart", self.index));
+      return Promise.resolve();
+    } else {
+      // restarting
+      self.tunnelProcess = null;
 
-          sauceConnectLauncher(self.options, (err, sauceConnectProcess) => {
-            if (err) {
-              logger.err(util.format("Error in starting Sauce Tunnel #%s \n %s", self.tunnelId, err));
-              // retry it 
-              if (self.retried < RETRY_LIMIT) {
-                self.retried += 1;
+      return new Promise((resolve, reject) => {
+        return Promise
+          // to avoid the blast of all tunnels launch up at same time 
+          .delay(Math.floor(Math.random() * DELAY_INTERVAL))
+          .then(() => {
+            logger.log(util.format("<starting...> Sauce Tunnel #%s", self.index));
 
-                return self
-                  .start()
-                  .then(resolve);
+            sauceConnectLauncher(self.options, (err, sauceConnectProcess) => {
+              if (err) {
+                logger.err(util.format("Error in starting Sauce Tunnel #%s \n %s", self.index, err));
+                // retry it 
+                if (self.retried < RETRY_LIMIT) {
+                  self.retried += 1;
+
+                  return self
+                    .start()
+                    .then(() => {
+                      resolve();
+                    });
+                } else {
+                  reject(err);
+                }
+
               } else {
-                reject(err);
-              }
+                self.tunnelProcess = sauceConnectProcess;
+                logger.log(util.format("<started> Sauce Tunnel #%s (%s)", self.index, self.tunnelProcess.tunnelId));
 
-            } else {
-              logger.log(util.format("Sauce Tunnel #%s has been started", self.tunnelId));
-              self.tunnelProcess = sauceConnectProcess;
-              self.isSkippingMonitor = false;
-              resolve();
-            }
+                resolve();
+              }
+            });
           });
-        });
-    });
+      });
+    }
   }
 
   stop(isTimer = false) {
     let self = this;
     self.isSkippingMonitor = isTimer;
 
-    return new Promise((resolve, reject) => {
-      return Promise
-        // to avoid the blast of all tunnels terminate at same time
-        .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-        .then(() => {
-          logger.log(util.format("Stopping Sauce Tunnel #%s, please be patient...", self.tunnelId));
+    return Promise
+      // to avoid the blast of terminating all tunnels at same time
+      .delay(Math.floor(Math.random() * DELAY_INTERVAL))
+      .then(() => {
+        // when current tunnel is told to stop
+        self.initStopAt = moment().valueOf();
+        logger.log(util.format("<stopping...> Sauce Tunnel #%s", self.index));
+
+        return new Promise((resolve, reject) => {
+          // since tunnelProcess.close() gives nothing back, we don't know if tunnel is closed succesfully or not.
+          // we always return resolve, leave other situation for kill()
           if (self.tunnelProcess && self.tunnelProcess["_handle"]) {
+            // tunnel is alive
             self.tunnelProcess.close(() => {
-              logger.log(util.format("Sauce Tunnel #%s has been successfully stopped", self.tunnelId));
+              logger.log(util.format("<stopped> Sauce Tunnel #%s", self.index));
               resolve();
             });
           } else {
-            logger.warn(util.format("Sauce Tunnel #%s doesn't exist or is safely closed, returning", self.tunnelId));
+            // one extra step is needed
+            logger.warn(util.format("Sauce Tunnel #%s doesn't exist or is safely closed, returning", self.index));
             resolve();
           }
         });
-    });
+      })
+      .then(() => self.kill())
+      .catch((err) => {
+        logger.err(util.format("Error in killing tunnel #%s with SIGKILL\n%s", self.index, err));
+        return Promise.reject(err);
+      });
+  }
+
+  kill() {
+    // we cannot say `Sauce Tunnel has been successfully stopped` at this time, sometimes 
+    // things can happen at saucelabs side so that sauce proxy got killed from their side
+    // but the child_process tunnel is alive at our side.
+    // however an extra step has been applied to check the availablility of the tunnel 
+    // from both side
+    let self = this;
+
+    if (self.tunnelProcess && !self.tunnelProcess["_handle"]) {
+      // _handle is null, tunnel is terminated correctly
+      self.initStopAt = null;
+      return Promise.resolve();
+
+    } else {
+      return Promise
+        .resolve()
+        .then(() => {
+          if (self.initStopAt && moment().valueOf() - self.initStopAt > MAX_ALIVE_DURATION) {
+            // something happened to stop current tunnel from being terminated
+            logger.warn(util.format("<killing with SIGKILL> Sauce Tunnel #%s doesn't terminate in %s!",
+              self.index,
+              moment.duration(MAX_ALIVE_DURATION).humanize()));
+
+            return new Promise((resolve, reject) => {
+              treeKill(self.tunnelProcess.pid, "SIGKILL", (err) => {
+                self.initStopAt = null;
+
+                if (err) {
+                  reject(err);
+                }
+                resolve();
+              });
+            });
+
+          } else {
+            // give it a moment
+            return Promise
+              .delay(MONITOR_INTERVAL)
+              .then(() => {
+                logger.warn(util.format("Sauce Tunnel #%s doesn't terminate on time but still in grace period. Waiting...", self.index));
+                return self.kill()
+              });
+          }
+        })
+        .catch((err) => {
+          // reject exception out
+          logger.err(util.format("Kill sauce Tunnel #%s failed\n%s", self.index, err));
+          return Promise.reject(err);
+        });
+    }
   }
 
   restart() {
     let self = this;
 
-    return Promise
-      .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-      .then(() => self.stop(true))
-      .then(() => self.start());
+    if (!self.isRestarting) {
+      self.isRestarting = true;
+
+      return Promise
+        .delay(Math.floor(Math.random() * DELAY_INTERVAL))
+        .then(() => self.stop(true))
+        .then(() => self.start())
+        .then(() => {
+          self.isSkippingMonitor = false;
+          self.isRestarting = false;
+        })
+        .catch((err) => {
+          self.isSkippingMonitor = false;
+          self.isRestarting = false;
+        });
+    } else {
+      // restart procedure is under going, do nothing 
+      return Promise.resolve();
+    }
   }
 
   monitor() {
     let self = this;
-    // reset retry attempt
-    self.retried = 0;
 
     return Promise
       .resolve()
       .then(() => {
+        // reset retry attempt
+        self.retried = 0;
+
         if ((self.tunnelProcess && self.tunnelProcess["_handle"]) || self.isSkippingMonitor) {
           //child process is still alive
           return Promise
             .delay(MONITOR_INTERVAL)
             .then(() => self.monitor());
         } else {
-          logger.warn(util.format("Sauce Tunnel #%s is dead, restarting it", self.tunnelId));
+          logger.warn(util.format("Sauce Tunnel #%s is dead, restarting it", self.index));
           return self
-            .stop()
-            .then(() => self.start())
+            .restart()
             .then(() => self.monitor());
         }
       });

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -20,10 +20,13 @@ const RETRY_LIMIT = 10;
 // maximum duration for a live tunnel in millisecond
 const MAX_ALIVE_DURATION = 300000;
 
+const STATE = {
+  IDLE: 0, STARTING: 1, RUNNING: 2, STOPPING: 3
+};
+
 export default class Tunnel {
   constructor(options) {
-    this.isSkippingMonitor = false;
-    this.isRestarting = false;
+    this.state = STATE.IDLE;
     this.retried = 0;
 
     this.tunnelProcess = null;
@@ -40,12 +43,14 @@ export default class Tunnel {
   start() {
     let self = this;
 
-    if (self.initStopAt) {
-      // a this.stop method is called somewhere, we do stop first. we'll restart the tunnel in next scheduled time slot
-      logger.warn(util.format("Sauce Tunnel #%s recieves a stop call while restarting, postpone restart", self.index));
+
+    if (self.state !== STATE.IDLE) {
+      // this.stop method is called somewhere, we do stop first. we'll restart the tunnel in next scheduled time slot
+      logger.warn(util.format("Sauce Tunnel #%s isn't idle, it's doing things", self.index));
       return Promise.resolve();
     } else {
       // restarting
+      self.state = STATE.STARTING;
       self.tunnelProcess = null;
 
       return new Promise((resolve, reject) => {
@@ -65,16 +70,18 @@ export default class Tunnel {
                   return self
                     .start()
                     .then(() => {
+                      self.state = STATE.RUNNING;
                       resolve();
                     });
                 } else {
+                  self.state = STATE.IDLE;
                   reject(err);
                 }
 
               } else {
                 self.tunnelProcess = sauceConnectProcess;
-                logger.log(util.format("<started> Sauce Tunnel #%s (%s)", self.index, self.tunnelProcess.tunnelId));
-
+                logger.log(util.format("<started> Sauce Tunnel #%s", self.index));
+                self.state = STATE.RUNNING;
                 resolve();
               }
             });
@@ -83,39 +90,46 @@ export default class Tunnel {
     }
   }
 
-  stop(isTimer = false) {
+  stop() {
     let self = this;
-    self.isSkippingMonitor = isTimer;
 
-    return Promise
-      // to avoid the blast of terminating all tunnels at same time
-      .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-      .then(() => {
-        // when current tunnel is told to stop
-        self.initStopAt = moment().valueOf();
-        logger.log(util.format("<stopping...> Sauce Tunnel #%s", self.index));
+    if (self.state === STATE.IDLE
+      || self.state === STATE.STOPPING) {
+      // dont do anything here
+      return Promise.resolve();
+    } else {
 
-        return new Promise((resolve, reject) => {
-          // since tunnelProcess.close() gives nothing back, we don't know if tunnel is closed succesfully or not.
-          // we always return resolve, leave other situation for kill()
-          if (self.tunnelProcess && self.tunnelProcess["_handle"]) {
-            // tunnel is alive
-            self.tunnelProcess.close(() => {
-              logger.log(util.format("<stopped> Sauce Tunnel #%s", self.index));
+      return Promise
+        // to avoid the blast of terminating all tunnels at same time
+        .delay(Math.floor(Math.random() * DELAY_INTERVAL))
+        .then(() => {
+          self.state = STATE.STOPPING;
+          // when current tunnel is told to stop
+          self.initStopAt = moment().valueOf();
+          logger.log(util.format("<stopping...> Sauce Tunnel #%s", self.index));
+
+          return new Promise((resolve, reject) => {
+            // since tunnelProcess.close() gives nothing back, we don't know if tunnel is closed succesfully or not.
+            // we always return resolve, leave other situation for kill()
+            if (self.tunnelProcess && self.tunnelProcess["_handle"]) {
+              // tunnel is alive
+              self.tunnelProcess.close(() => {
+                logger.log(util.format("<stopped> Sauce Tunnel #%s", self.index));
+                resolve();
+              });
+            } else {
+              // one extra step is needed
+              logger.warn(util.format("Sauce Tunnel #%s doesn't exist or is safely closed, returning", self.index));
               resolve();
-            });
-          } else {
-            // one extra step is needed
-            logger.warn(util.format("Sauce Tunnel #%s doesn't exist or is safely closed, returning", self.index));
-            resolve();
-          }
+            }
+          });
+        })
+        .then(() => self.kill())
+        .catch((err) => {
+          logger.err(util.format("Error in killing tunnel #%s with SIGKILL\n%s", self.index, err));
+          return Promise.reject(err);
         });
-      })
-      .then(() => self.kill())
-      .catch((err) => {
-        logger.err(util.format("Error in killing tunnel #%s with SIGKILL\n%s", self.index, err));
-        return Promise.reject(err);
-      });
+    }
   }
 
   kill() {
@@ -126,8 +140,10 @@ export default class Tunnel {
     // from both side
     let self = this;
 
-    if (self.tunnelProcess && !self.tunnelProcess["_handle"]) {
+    if (self.tunnelProcess
+      && !self.tunnelProcess["_handle"]) {
       // _handle is null, tunnel is terminated correctly
+      self.state = STATE.IDLE;
       self.initStopAt = null;
       return Promise.resolve();
 
@@ -135,7 +151,8 @@ export default class Tunnel {
       return Promise
         .resolve()
         .then(() => {
-          if (self.initStopAt && moment().valueOf() - self.initStopAt > MAX_ALIVE_DURATION) {
+          if (self.initStopAt
+            && moment().valueOf() - self.initStopAt > MAX_ALIVE_DURATION) {
             // something happened to stop current tunnel from being terminated
             logger.warn(util.format("<killing with SIGKILL> Sauce Tunnel #%s doesn't terminate in %s!",
               self.index,
@@ -148,6 +165,7 @@ export default class Tunnel {
                 if (err) {
                   reject(err);
                 }
+                self.state = STATE.IDLE;
                 resolve();
               });
             });
@@ -164,6 +182,7 @@ export default class Tunnel {
         })
         .catch((err) => {
           // reject exception out
+          self.state = STATE.RUNNING;
           logger.err(util.format("Kill sauce Tunnel #%s failed\n%s", self.index, err));
           return Promise.reject(err);
         });
@@ -173,20 +192,19 @@ export default class Tunnel {
   restart() {
     let self = this;
 
-    if (!self.isRestarting) {
-      self.isRestarting = true;
+    if (self.state === STATE.IDLE
+      || self.state === STATE.RUNNING) {
+      // restart is only allowed on idle or running state
 
       return Promise
         .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-        .then(() => self.stop(true))
+        .then(() => self.stop())
         .then(() => self.start())
         .then(() => {
-          self.isSkippingMonitor = false;
-          self.isRestarting = false;
+          self.state = STATE.RUNNING;
         })
         .catch((err) => {
-          self.isSkippingMonitor = false;
-          self.isRestarting = false;
+          self.state = STATE.IDLE;
         });
     } else {
       // restart procedure is under going, do nothing 
@@ -203,7 +221,9 @@ export default class Tunnel {
         // reset retry attempt
         self.retried = 0;
 
-        if ((self.tunnelProcess && self.tunnelProcess["_handle"]) || self.isSkippingMonitor) {
+        if ((self.tunnelProcess && self.tunnelProcess["_handle"])
+          || self.state === STATE.STOPPING
+          || self.state === STATE.STARTING) {
           //child process is still alive
           return Promise
             .delay(MONITOR_INTERVAL)

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -18,11 +18,14 @@ const DELAY_INTERVAL = 5000;
 // maximum retry times before a tunnel goes alive in millisecond
 const RETRY_LIMIT = 10;
 // maximum duration for a live tunnel in millisecond
-const MAX_ALIVE_DURATION = 300000;
+const TUNNEL_STOP_TIMEOUT = 480000;
+const TUNNEL_START_TIMEOUT = 480000;
 
 const STATE = {
   IDLE: 0, STARTING: 1, RUNNING: 2, STOPPING: 3
 };
+
+Promise.config({ cancellation: true });
 
 export default class Tunnel {
   constructor(options) {
@@ -32,17 +35,15 @@ export default class Tunnel {
     this.tunnelProcess = null;
     this.index = options.id;
     this.pidTempPath = options.pidTempPath;
-    this.initStopAt = null;
 
     this.options = _.omit(options, privateOptions);
     // add individual info per tunnel
-    this.options.readyFileId = this.index.toString();
+    this.options.readyFileId = util.format("%s_%s", Math.ceil(Math.random() * 1000), this.index.toString());
     this.options.pidfile = path.resolve(this.pidTempPath, this.index.toString() + ".pid");
   }
 
   start() {
     let self = this;
-
 
     if (self.state !== STATE.IDLE) {
       // this.stop method is called somewhere, we do stop first. we'll restart the tunnel in next scheduled time slot
@@ -53,40 +54,60 @@ export default class Tunnel {
       self.state = STATE.STARTING;
       self.tunnelProcess = null;
 
-      return new Promise((resolve, reject) => {
-        return Promise
-          // to avoid the blast of all tunnels launch up at same time 
-          .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-          .then(() => {
-            logger.log(util.format("<starting...> Sauce Tunnel #%s", self.index));
+      let timeout = setTimeout(() => p.cancel(), TUNNEL_START_TIMEOUT);
+      let p = new Promise((resolve, reject, onCancel) => {
+        onCancel(() => {
+          self.state = STATE.IDLE;
+          logger.err(util.format("Sauce Tunnel #%s times out while starting", self.index));
+        });
 
-            sauceConnectLauncher(self.options, (err, sauceConnectProcess) => {
-              if (err) {
-                logger.err(util.format("Error in starting Sauce Tunnel #%s \n %s", self.index, err));
-                self.state = STATE.IDLE;
-                // retry it 
-                if (self.retried < RETRY_LIMIT) {
-                  self.retried += 1;
+        sauceConnectLauncher(self.options, (err, sauceConnectProcess) => {
+          if (err) {
+            logger.err(util.format("Error in starting Sauce Tunnel #%s \n %s", self.index, err));
+            // retry it 
+            if (self.retried < RETRY_LIMIT) {
+              self.retried += 1;
+              self.state = STATE.IDLE;
 
-                  return self
-                    .start()
-                    .then(() => {
-                      self.state = STATE.RUNNING;
-                      resolve();
-                    });
-                } else {
-                  reject(err);
-                }
+              return self
+                .start()
+                .then(() => {
+                  self.state = STATE.RUNNING;
+                  resolve();
+                });
+            } else {
+              self.state = STATE.IDLE;
+              logger.err(util.format("Error in starting Sauce Tunnel #%s \n %s", self.index, err));
+              reject(err);
+            }
 
-              } else {
-                self.tunnelProcess = sauceConnectProcess;
-                logger.log(util.format("<started> Sauce Tunnel #%s", self.index));
-                self.state = STATE.RUNNING;
-                resolve();
-              }
-            });
-          });
+          } else {
+            self.tunnelProcess = sauceConnectProcess;
+            logger.log(util.format("<started> Sauce Tunnel #%s", self.index));
+            self.state = STATE.RUNNING;
+            resolve();
+          }
+        });
       });
+
+      return Promise
+        // to avoid the blast of all tunnels launch up at same time  
+        .delay(Math.floor(Math.random() * DELAY_INTERVAL))
+        .then(() => {
+          logger.log(util.format("<starting...> Sauce Tunnel #%s", self.index));
+
+
+          return p;
+        })
+        .finally(() => {
+          clearTimeout(timeout);
+          this.retried = 0;
+          if (p.isCancelled()) {
+            return Promise.reject();
+          } else {
+            return Promise.resolve();
+          }
+        });
     }
   }
 
@@ -98,42 +119,44 @@ export default class Tunnel {
       // dont do anything here
       return Promise.resolve();
     } else {
+      self.state = STATE.STOPPING;
+      let timeout = setTimeout(() => p.cancel(), TUNNEL_STOP_TIMEOUT);
+      let p = new Promise((resolve, reject, onCancel) => {
+
+        onCancel(() => {
+          logger.err(util.format("Sauce Tunnel #%s times out while stopping", self.index));
+        });
+
+        // since tunnelProcess.close() gives nothing back, we don't know if tunnel is closed succesfully or not.
+        // we always return resolve, leave other situation for kill()
+        if (self.tunnelProcess && self.tunnelProcess["_handle"]) {
+
+          logger.log(util.format("<stopping...> Sauce Tunnel #%s", self.index));
+          // tunnel is alive
+          self.tunnelProcess.close(() => {
+            // where zombie tunnel is born
+            logger.log(util.format("<stopped> Sauce Tunnel #%s", self.index));
+            resolve();
+          });
+        } else {
+          // one extra step is needed
+          logger.warn(util.format("Sauce Tunnel #%s doesn't exist or is safely closed, returning", self.index));
+          resolve();
+        }
+      });
 
       return Promise
         // to avoid the blast of terminating all tunnels at same time
         .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-        .then(() => {
-          self.state = STATE.STOPPING;
-          // when current tunnel is told to stop
-          self.initStopAt = moment().valueOf();
-          logger.log(util.format("<stopping...> Sauce Tunnel #%s", self.index));
-
-          return new Promise((resolve, reject) => {
-            // since tunnelProcess.close() gives nothing back, we don't know if tunnel is closed succesfully or not.
-            // we always return resolve, leave other situation for kill()
-            if (self.tunnelProcess && self.tunnelProcess["_handle"]) {
-              // tunnel is alive
-              self.tunnelProcess.close(() => {
-                // where zombie tunnel is born
-                logger.log(util.format("<stopped> Sauce Tunnel #%s", self.index));
-                resolve();
-              });
-            } else {
-              // one extra step is needed
-              logger.warn(util.format("Sauce Tunnel #%s doesn't exist or is safely closed, returning", self.index));
-              resolve();
-            }
-          });
-        })
-        .then(() => self.kill())
-        .catch((err) => {
-          logger.err(util.format("Error in killing tunnel #%s with SIGKILL\n%s", self.index, err));
-          return Promise.reject(err);
+        .then(() => p)
+        .finally(() => {
+          clearTimeout(timeout)
+          return self.kill(p.isCancelled())
         });
     }
   }
 
-  kill() {
+  kill(isTimeout = false) {
     // we cannot say `Sauce Tunnel has been successfully stopped` at this time, sometimes 
     // things can happen at saucelabs side so that sauce proxy got killed from their side
     // but the child_process tunnel is alive at our side.
@@ -141,52 +164,32 @@ export default class Tunnel {
     // from both side
     let self = this;
 
-    if (!self.tunnelProcess
-      || !self.tunnelProcess["_handle"]) {
+    if (!isTimeout || !self.tunnelProcess) {
       // _handle is null, tunnel is terminated correctly, or tunnel child_process is set to be null
       self.state = STATE.IDLE;
-      self.initStopAt = null;
       return Promise.resolve();
 
     } else {
-      return Promise
-        .resolve()
-        .then(() => {
-          if (self.initStopAt
-            && moment().valueOf() - self.initStopAt > MAX_ALIVE_DURATION) {
-            // something happened to stop current tunnel from being terminated
-            logger.warn(util.format("<killing with SIGKILL> Sauce Tunnel #%s doesn't terminate in %s!",
-              self.index,
-              moment.duration(MAX_ALIVE_DURATION).humanize()));
+      // something happened to stop current tunnel from being terminated
+      logger.warn(util.format("<killing with SIGKILL...> Sauce Tunnel #%s doesn't terminate in %s!",
+        self.index,
+        moment.duration(TUNNEL_STOP_TIMEOUT).humanize()));
 
-            return new Promise((resolve, reject) => {
-              treeKill(self.tunnelProcess.pid, "SIGKILL", (err) => {
-                self.initStopAt = null;
+      return new Promise((resolve, reject) => {
+        treeKill(self.tunnelProcess.pid, "SIGKILL", (err) => {
 
-                if (err) {
-                  reject(err);
-                }
-                self.state = STATE.IDLE;
-                resolve();
-              });
-            });
-
+          if (err) {
+            self.state = STATE.RUNNING;
+            logger.err(util.format("Kill sauce Tunnel #%s failed\n%s", self.index, err));
+            reject(err);
           } else {
-            // give it a moment
-            return Promise
-              .delay(MONITOR_INTERVAL)
-              .then(() => {
-                logger.warn(util.format("Sauce Tunnel #%s doesn't terminate on time but still in grace period. Waiting...", self.index));
-                return self.kill()
-              });
+            self.state = STATE.IDLE;
+            self.tunnelProcess = null;
+            logger.warn(util.format("<killed with SIGKILL> Sauce Tunnel #%s!", self.index));
+            resolve();
           }
-        })
-        .catch((err) => {
-          // reject exception out
-          self.state = STATE.RUNNING;
-          logger.err(util.format("Kill sauce Tunnel #%s failed\n%s", self.index, err));
-          return Promise.reject(err);
         });
+      });
     }
   }
 
@@ -199,13 +202,18 @@ export default class Tunnel {
 
       return Promise
         .delay(Math.floor(Math.random() * DELAY_INTERVAL))
-        .then(() => self.stop())
-        .then(() => self.start())
+        .then(() => {
+          return self.stop()
+        })
+        .then(() => {
+          return self.start()
+        })
         .then(() => {
           self.state = STATE.RUNNING;
-        })
-        .catch((err) => {
-          self.state = STATE.IDLE;
+          return Promise.resolve();
+        }, (err) => {
+          logger.warn(util.format("Sauce Tunnel #%s failled in restarting, waiting for next rolling restart schedule\n%s", self.index, err));
+          return Promise.reject(err);
         });
     } else {
       // restart procedure is under going, do nothing 
@@ -221,7 +229,6 @@ export default class Tunnel {
       .then(() => {
         // reset retry attempt
         self.retried = 0;
-
         if ((self.tunnelProcess && self.tunnelProcess["_handle"])
           || self.state === STATE.STOPPING
           || self.state === STATE.STARTING) {

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -63,6 +63,7 @@ export default class Tunnel {
             sauceConnectLauncher(self.options, (err, sauceConnectProcess) => {
               if (err) {
                 logger.err(util.format("Error in starting Sauce Tunnel #%s \n %s", self.index, err));
+                self.state = STATE.IDLE;
                 // retry it 
                 if (self.retried < RETRY_LIMIT) {
                   self.retried += 1;
@@ -74,7 +75,6 @@ export default class Tunnel {
                       resolve();
                     });
                 } else {
-                  self.state = STATE.IDLE;
                   reject(err);
                 }
 
@@ -114,6 +114,7 @@ export default class Tunnel {
             if (self.tunnelProcess && self.tunnelProcess["_handle"]) {
               // tunnel is alive
               self.tunnelProcess.close(() => {
+                // where zombie tunnel is born
                 logger.log(util.format("<stopped> Sauce Tunnel #%s", self.index));
                 resolve();
               });
@@ -140,9 +141,9 @@ export default class Tunnel {
     // from both side
     let self = this;
 
-    if (self.tunnelProcess
-      && !self.tunnelProcess["_handle"]) {
-      // _handle is null, tunnel is terminated correctly
+    if (!self.tunnelProcess
+      || !self.tunnelProcess["_handle"]) {
+      // _handle is null, tunnel is terminated correctly, or tunnel child_process is set to be null
       self.state = STATE.IDLE;
       self.initStopAt = null;
       return Promise.resolve();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "once": "^1.4.0",
     "pm2": "^2.0.12",
     "sauce-connect-launcher": "^0.16.0",
+    "tree-kill": "^1.1.0",
     "yargs": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node-schedule": "^1.1.1",
     "once": "^1.4.0",
     "pm2": "^2.0.12",
-    "sauce-connect-launcher": "^0.17.0",
+    "sauce-connect-launcher": "^1.1.0",
     "tree-kill": "^1.1.0",
     "yargs": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node-schedule": "^1.1.1",
     "once": "^1.4.0",
     "pm2": "^2.0.12",
-    "sauce-connect-launcher": "^0.16.0",
+    "sauce-connect-launcher": "^1.1.0",
     "tree-kill": "^1.1.0",
     "yargs": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node-schedule": "^1.1.1",
     "once": "^1.4.0",
     "pm2": "^2.0.12",
-    "sauce-connect-launcher": "^1.1.0",
+    "sauce-connect-launcher": "^0.17.0",
     "tree-kill": "^1.1.0",
     "yargs": "^5.0.0"
   }


### PR DESCRIPTION
new rules for zombie detection are 
1. if a tunnel failed in launching (times out, 8min), it'll be killed and background monitor will try to launch it again in a certain time (10 seconds for now)
2. if a tunnel failed in stopping (times out, 8min), it'll be killed by `SIGKILL` 

some enhancements
1. add node child process health detection to prevent calls from `null` or `undefined` (from tunnelProcess)
2. more robust error detection
3. informative log

@Maciek416 @geekdave 