### PR TITLE
Add data adaptor for stats pushing and future extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ You can set `tunnel.username` and `tunnel.accessKey` using one of the following 
 
 #### Stats config
 
-From `@1.3.0` crows-nest starts to support pushing stats to a statsd-like system. To utilize this data pushing function you need to explicitly add `--stats` in your command. There are only two adaptors supported for now, adaptor for [telegraf](https://github.com/influxdata/telegraf) and adaptor for pushing data into influxdb directly. You can extend `lib/stats/base` to add more adaptors.
+From `@1.3.0` crows-nest starts to support pushing stats to a statsd-like system. To utilize this data pushing function you need to explicitly add `--stats` in your command. There are only two adaptors supported for now, adaptor for [telegraf](https://github.com/influxdata/telegraf) and adaptor for pushing data into influxdb directly. You can extend `lib/stats/base` to add more adaptors. 
+
+For instance, in `config.json`, `stats.statsType =  influxdb` will tell the adaptor factory to look for a mapping with key `influxdb` configured in `factory.js`. Adaptor factory will return an instance of influxdb adaptor which is defined in `influxdb.js`. If there is no adaptor found by adaptor factory, it will throw an error to prevent crows-nest from starting.
 
 Stats only supports `gauge` for now.
 

--- a/README.md
+++ b/README.md
@@ -25,30 +25,58 @@ Since Crows-nest is coded in ES6, you might need to compile it before running it
 ```
 ./config.json
 {
-  "username": "",
-  "accessKey": "",
-  "verbose": false,
-  "proxy": null,
-  "tunnelIdentifier": "",
-  "waitTunnelShutdown": true,
-  "noRemoveCollidingTunnels": true,
+  "tunnel": {
+    "username": "",
+    "accessKey": "",
+    "verbose": false,
+    "proxy": null,
+    "tunnelIdentifier": "",
+    "waitTunnelShutdown": true,
+    "noRemoveCollidingTunnels": true,
+    "sharedTunnel": true
+  },
+  "stats": {
+    "statsType": "",
+    "statsHost": "",
+    "statsPort": null,
+    "statsPrefix": "",
+    "statsDatabase": ""
+  },
 
   "restartCron": "0 */4 * * *"
 }
 ```
 
-`./config.json` file has the basic configurations that are required by Sauce Connect. To launch your own tunnels, `username`, `accessKey` and `tunnelIdentifier` are mandatory. 
+`./config.json` file has the basic configurations that are required by Sauce Connect. 
 
-More configurations please refer to this page [sauce-connect-launcher](https://github.com/bermi/sauce-connect-launcher#advanced-usage).
+#### Tunnel config
 
-In high availability mode all tunnels share the same `tunnelIdentifier`. `tunnelIdentifier` can be any string.  One suggested convention is to use this ID to describe the geographical location where your tunnel terminates.  For example, `east` or `west`.  
+To launch your own tunnels, `tunnel.username`, `tunnel.accessKey` and `tunnel.tunnelIdentifier` are mandatory. More configurations please refer to this page [sauce-connect-launcher](https://github.com/bermi/sauce-connect-launcher#advanced-usage).
+
+In high availability mode all tunnels share the same `tunnel.tunnelIdentifier`. `tunnel.tunnelIdentifier` can be any string.  One suggested convention is to use this ID to describe the geographical location where your tunnel terminates.  For example, `east` or `west`.  
 
 The `restartCron` value is any valid cron schedule.  For example `0 */4 * * *` would mean "every 4 hours".  We recommend [crontab.guru](http://crontab.guru/examples.html) for help generating valid cron strings to match the desired schedule.
 
-You can set `username` and `accessKey` using one of the following methods:
+You can set `tunnel.username` and `tunnel.accessKey` using one of the following methods:
  
  1. Specifying the values in `./config.json`
- 2. Setting the environment variable `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`  
+ 2. Setting the environment variable `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`
+
+#### Stats config
+
+From `@1.3.0` crows-nest starts to support pushing stats to a statsd-like system. To utilize this data pushing function you need to explicitly add `--stats` in your command. There are only two adaptors supported for now, adaptor for [telegraf](https://github.com/influxdata/telegraf) and adaptor for pushing data into influxdb directly. You can extend `lib/stats/base` to add more adaptors.
+
+Stats only supports `gauge` for now.
+
+Following data will be gathered and pushed
+ 1. How many connection attempts a tunnel has been made before failing
+ 2. How many connection attempts a tunnel has been made for now 
+ 3. How many attempts a tunnel has been made to successfully connect
+ 4. When a tunnel successfully stopped
+ 5. How long a tunnel run (unix timestamp)
+ 6. How long a tunnel takes to successfully connect
+
+#### Other configs
 
 If the rolling restart feature is enabled, `restartCron` must be a valid cron value.
 
@@ -72,9 +100,9 @@ SAUCE_USERNAME=xxx SAUCE_ACCESS_KEY=yyy ./bin/supervise --tunnels 1 --rollingRes
 
 ### Advanced usage
 
-Read sauce tunnel configuration from `./myproject/config.json` and launch 20 sauce tunnels in high availability mode
+Read sauce tunnel configuration from `./myproject/config.json` and launch 20 sauce tunnels in high availability mode, with rolling restarted and stats data pushing feature enabled
 ```
-./bin/supervise --tunnels 20 --config ./myproject/config.json
+./bin/supervise --tunnels 20 --config ./myproject/config.json --rollingRestart --stats
 ```
 
 ### Daemon

--- a/config.json
+++ b/config.json
@@ -1,17 +1,20 @@
 {
-  "username": "",
-  "accessKey": "",
-  "verbose": false,
-  "proxy": null,
-  "tunnelIdentifier": "",
-  "waitTunnelShutdown": true,
-  "noRemoveCollidingTunnels": true,
-  "sharedTunnel": true,
-
-  "restartCron": "0 3 * * *",
-
-  "statsdHost": "",
-  "statsdPort": null,
-  "statsdPrefix": ".",
-  "telegraf": true
+  "tunnel": {
+    "username": "",
+    "accessKey": "",
+    "verbose": false,
+    "proxy": null,
+    "tunnelIdentifier": "",
+    "waitTunnelShutdown": true,
+    "noRemoveCollidingTunnels": true,
+    "sharedTunnel": true
+  },
+  "stats": {
+    "statsType": "influxdb",
+    "statsHost": "",
+    "statsPort": null,
+    "statsPrefix": "testdddtest.",
+    "statsDatabase": ""
+  },
+  "restartCron": "0 3 * * *"
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -10,22 +10,22 @@ const debug = argvs.argv.debug;
 export default {
   output: console,
 
-  debug(msg) {
+  debug(...msgs) {
     if (debug) {
       var deb = clc.blueBright("[DEBUG]");
-      this.output.log(util.format("[%s] %s %s", moment().format("YYYY-MM-DD HH:mm:ss.SSS"), deb, msg));
+      this.output.log(util.format("[%s] %s %s", moment().format("YYYY-MM-DD HH:mm:ss.SSS"), deb, msgs.join("|")));
     }
   },
-  log(msg) {
+  log(...msgs) {
     var info = clc.greenBright("[INFO]");
-    this.output.log(util.format("[%s] %s %s", moment().format("YYYY-MM-DD HH:mm:ss.SSS"), info, msg));
+    this.output.log(util.format("[%s] %s %s", moment().format("YYYY-MM-DD HH:mm:ss.SSS"), info, msgs.join("|")));
   },
-  warn(msg) {
+  warn(...msgs) {
     var warn = clc.yellowBright("[WARN]");
-    this.output.warn(util.format("[%s] %s %s", moment().format("YYYY-MM-DD HH:mm:ss.SSS"), warn, msg));
+    this.output.warn(util.format("[%s] %s %s", moment().format("YYYY-MM-DD HH:mm:ss.SSS"), warn, msgs.join("|")));
   },
-  err(msg) {
+  err(...msgs) {
     var err = clc.redBright("[ERROR]");
-    this.output.error(util.format("[%s] %s %s", moment().format("YYYY-MM-DD HH:mm:ss.SSS"), err, msg));
+    this.output.error(util.format("[%s] %s %s", moment().format("YYYY-MM-DD HH:mm:ss.SSS"), err, msgs.join("|")));
   }
 };

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,6 +1,5 @@
 "use strict";
 
-import StatsD from "hot-shots";
 import Promise from "bluebird";
 import _ from "lodash";
 import EventEmitter from "events";
@@ -8,6 +7,7 @@ import util from "util";
 import os from "os";
 
 import logger from "./logger";
+import Factory from "./stats/factory";
 
 export const EVENT = {
   TUNNEL_STATUS: "status",
@@ -25,21 +25,14 @@ export const EVENT = {
   TUNNEL_BUILD_CONNECTITON: "connectcost"
 };
 
-export class StatsQueue extends EventEmitter {
+export class StatsQueue {
   constructor(options) {
-    super();
-
     this.statsQueue = this.build();
-    this.statsSwitch = options.statsSwitch;
-    this.statsdHost = options.statsdHost;
-    this.statsdPort = options.statsdPort;
-    this.statsdPrefix = options.statsdPrefix;
 
-    this.statsClient = options.statsD ? options.statsD : new StatsD({
-      host: this.statsdHost + (this.statsdPort ? ":" + this.statsdPort : ""),
-      telegraf: options.telegraf,
-      globalTags: ["hostname:" + os.hostname()]
-    });
+    this.statsSwitch = options.statsSwitch;
+    this.statsPrefix = options.statsPrefix;
+
+    this.statsClient = options.statsClient ? options.statsClient : new Factory(options.statsType, _.omit(options, "statsSwitch"));
 
   }
 
@@ -61,7 +54,7 @@ export class StatsQueue extends EventEmitter {
         tempQueue.push(self._generateStats(v2.event));
       });
     });
-
+    
     return Promise
       .all(tempQueue)
       .then(() => {
@@ -79,7 +72,12 @@ export class StatsQueue extends EventEmitter {
      *    event: {
      *      tunnelid: {
      *        timestamp: number
-     *        event: Promise
+     *        event: {
+     *          eventType: string,
+     *          timestamp: number,
+     *          tunnelIndex: number,
+     *          data: number
+     *        }
      *      }
      *    }
      * }
@@ -110,11 +108,15 @@ export class StatsQueue extends EventEmitter {
     let self = this;
 
     return new Promise((resolve, reject) => {
-      let stat = util.format("%s%s", self.statsdPrefix, eventType, tunnelIndex, data);
-      logger.debug(stat, data, ["tunnelNum:" + tunnelIndex]);
+      let key = util.format("%s%s", self.statsPrefix, eventType);
 
-      self.statsClient.gauge(stat, data, ["tunnelNum:" + tunnelIndex]);
-      resolve();
+      self.statsClient
+        .gauge(key, timestamp, data, ["hostname:" + os.hostname(), "tunnelNum:" + tunnelIndex])
+        .then(() => {
+          // we eat all errors here as some of the clients use UDP
+          resolve();
+        });
+
     });
   }
 };

--- a/lib/stats/base.js
+++ b/lib/stats/base.js
@@ -1,0 +1,13 @@
+"use strict";
+
+import Promise from "bluebird";
+
+export default class BaseStats {
+  constructor(options) {
+
+  }
+
+  gauge(key, timestamp, data, tags, callback) {
+    return Promise.resolve();
+  }
+};

--- a/lib/stats/factory.js
+++ b/lib/stats/factory.js
@@ -17,6 +17,6 @@ export default class AdaptorFactory {
     }
 
     logger.err(util.format("Stats adaptor %s isn't supported, please implement the adaptor in lib/stats/", type));
-    return new Error("No such stats adaptor found in lib/stats/");
+    throw new Error("No such stats adaptor found in lib/stats/");
   }
 };

--- a/lib/stats/factory.js
+++ b/lib/stats/factory.js
@@ -1,0 +1,22 @@
+"use strict";
+
+import util from "util";
+import Influx from "./influxdb";
+import Telegraf from "./telegraf";
+import logger from "../logger";
+
+const adaptors = {
+  influxdb: Influx,
+  telegraf: Telegraf
+}
+
+export default class AdaptorFactory {
+  constructor(type, options) {
+    if (adaptors[type]) {
+      return new adaptors[type](options);
+    }
+
+    logger.err(util.format("Stats adaptor %s isn't supported, please implement the adaptor in lib/stats/", type));
+    return new Error("No such stats adaptor found in lib/stats/");
+  }
+};

--- a/lib/stats/influxdb.js
+++ b/lib/stats/influxdb.js
@@ -1,0 +1,32 @@
+"use strict";
+
+import { InfluxDB } from "influx";
+import moment from "moment";
+import _ from "lodash";
+import Base from "./base";
+import logger from "../logger";
+
+export default class InfluxDBAdaptor extends Base {
+  constructor({statsHost, statsPort, statsDatabase}) {
+    super();
+    
+    this.influx = new InfluxDB({
+      host: statsHost,
+      port: statsPort,
+      database: statsDatabase
+    });
+  }
+
+  gauge(key, timestamp, data, tags, callback) {
+    // data mapping and format
+
+    let d = {
+      measurement: key,
+      tags: _.fromPairs(_.map(tags, (t) => t.split(":"))),
+      fields: { duration: timestamp, value: data },
+    };
+    logger.debug(JSON.stringify(d));
+    // return a promise
+    return this.influx.writePoints([d]);
+  }
+};

--- a/lib/stats/telegraf.js
+++ b/lib/stats/telegraf.js
@@ -1,0 +1,26 @@
+"use strict";
+
+import HotShots from "hot-shots";
+import Promise from "bluebird";
+import Base from "./base";
+import logger from "../logger";
+
+export default class TelegrafAdaptor extends Base {
+  constructor({statsHost, statsPort, statsTelegraf}) {
+    super();
+    
+    this.hotshots = new HotShots({
+      host: statsHost,
+      port: statsPort,
+      telegraf: statsTelegraf
+    });
+  }
+
+  gauge(key, timestamp, data, tags, callback) {
+    logger.debug(key, data, tags);
+    // hot-shots uses UDP
+    this.hotshots.gauge(key, data, tags);
+
+    return Promise.resolve();
+  }
+};

--- a/lib/supervise.js
+++ b/lib/supervise.js
@@ -46,9 +46,10 @@ let stats = !!argv.stats;
 
 let supervisor = new Supervisor({
   tunnelAmount: tunnels,
-  tunnelConfig: config,
+  tunnelConfig: config.tunnel,
   restartCron: restartCron,
-  statsSwitch: stats
+  statsSwitch: stats,
+  statsConfig: config.stats
 });
 
 let exitProcess = once((signal) => {

--- a/lib/supervise.js
+++ b/lib/supervise.js
@@ -38,8 +38,8 @@ let rollingRestart = !!argv.rollingRestart;
 //load config from given path 
 let configPath = argv.config ? path.resolve(process.cwd(), argv.config) : "../config.json";
 let config = require(configPath);
-// 2:00am every day
-let restartCron = config.restartCron || "0 2 * * *";
+// only set restartCron when rollingRestart is enabled 
+let restartCron = rollingRestart ? config.restartCron || "0 2 * * *" : null;
 
 // stats
 let stats = !!argv.stats;

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -23,7 +23,8 @@ export default class Supervisor {
     this.tunnelConfig = tunnelConfig;
     this.tunnelAmount = tunnelAmount;
     this.restartCron = restartCron;
-    
+    this.statsConfig = statsConfig;
+
     this.statsSwitch = statsSwitch;
     this.statsQueue = new StatsQueue(_.extend(statsConfig, {
       statsSwitch: statsSwitch,
@@ -38,7 +39,14 @@ export default class Supervisor {
       // download sauce tunnel if necessary
       logger.log("/*************************************************/");
       logger.log(util.format("Preparing %d Sauce Tunnel(s)", this.tunnelAmount));
-      logger.log(util.format("Rolling restart is enabled with schedule: %s", this.restartCron));
+      
+      if (this.restartCron) {
+        logger.log(util.format("Rolling restart is enabled with schedule: %s", this.restartCron));
+      }
+
+      if(this.statsSwitch){
+        logger.log(util.format("Stats is enabled with adaptor: %s", this.statsConfig.statsType));
+      }
       logger.log("/*************************************************/");
 
       for (let i = 0; i < this.tunnelAmount; i++) {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -18,20 +18,19 @@ const PID_TEMP_PATH = path.resolve(process.cwd(), "temp");
 const RESTART_INTERVAL = 86400000;
 
 export default class Supervisor {
-  constructor({tunnelConfig, tunnelAmount, restartCron, statsSwitch}) {
+  constructor({tunnelConfig, tunnelAmount, restartCron, statsSwitch, statsConfig}) {
     this.tunnels = [];
     this.tunnelConfig = tunnelConfig;
     this.tunnelAmount = tunnelAmount;
     this.restartCron = restartCron;
-
+    
     this.statsSwitch = statsSwitch;
-    this.statsQueue = new StatsQueue(_.extend(this.tunnelConfig, {
+    this.statsQueue = new StatsQueue(_.extend(statsConfig, {
       statsSwitch: statsSwitch,
-      statsD: statsSwitch ? null : { gauge() { } }
+      statsClient: statsSwitch ? null : { gauge() { return Promise.resolve(); } }
     }));
 
     this.statsHandle = null;
-
   }
 
   stage() {

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -12,7 +12,7 @@ import moment from "moment";
 import logger from "./logger";
 import { EVENT } from "./stats";
 
-const privateOptions = Array.of("id", "pidTempPath", "restartCron", "statsdHost", "statsdPort", "statsdPrefix", "statsQueue", "statsSwitch", "statsD", "telegraf");
+const privateOptions = Array.of("id", "pidTempPath", "restartCron", "statsQueue");
 
 // frequency to check if a tunnel is alive in millisecond
 const MONITOR_INTERVAL = 10000;
@@ -54,7 +54,7 @@ export class Tunnel {
 
   start(retries = 0) {
     let self = this;
-
+    
     if (self.state !== STATE.IDLE) {
       // this.stop method is called somewhere, we do stop first. we'll restart the tunnel in next scheduled time slot
       logger.warn(util.format("Sauce Tunnel #%s isn't idle, it's doing things", self.index));

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "chai-as-promised": "^6.0.0",
     "cli-color": "^1.1.0",
     "hot-shots": "^4.3.1",
+    "influx": "^5.0.0-alpha.4",
     "lodash": "^4.15.0",
     "mocha": "^3.2.0",
     "moment": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "testarmada-crows-nest",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "supervise sauce tunnels, restart one if dies",
   "scripts": {
     "build": "./node_modules/.bin/babel lib --out-dir dist --source-maps",
     "build-test": "./node_modules/.bin/babel test --out-dir dist/test --source-maps",
-    "test": "npm run build && npm run build-test && ./node_modules/.bin/mocha dist/test"
+    "test": "npm run build && npm run build-test && ./node_modules/.bin/mocha --recursive dist/test"
   },
   "repository": {
     "type": "git",

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -40,8 +40,6 @@ describe("Stats", () => {
 
   it("Initialization", () => {
     expect(s.statsSwitch).to.equal(options.statsSwitch);
-    expect(s.statsHost).to.equal(options.statsHost);
-    expect(s.statsPort).to.equal(options.statsPort);
     expect(s.statsPrefix).to.equal(options.statsPrefix);
   });
 

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -21,28 +21,28 @@ const expect = chai.expect;
 const assert = chai.assert;
 
 describe("Stats", () => {
-  let statsDMock = null;
+  let statsMock = null;
 
   let options = {
     statsSwitch: false,
-    statsdHost: "some.where.local.org",
-    statsdPort: null,
-    statsdPrefix: "fake."
+    statsHost: "some.where.local.org",
+    statsPort: null,
+    statsPrefix: "fake."
   };
 
   let s = null;
 
   beforeEach(() => {
-    statsDMock = { gauge(stat, data, tags) { } };
+    statsMock = { gauge(key, timestamp, data, tags, callback) { return Promise.resolve() } };
 
-    s = new StatsQueue(_.extend({}, options, { statsD: statsDMock }));
+    s = new StatsQueue(_.extend({}, options, { statsClient: statsMock }));
   });
 
   it("Initialization", () => {
     expect(s.statsSwitch).to.equal(options.statsSwitch);
-    expect(s.statsdHost).to.equal(options.statsdHost);
-    expect(s.statsdPort).to.equal(options.statsdPort);
-    expect(s.statsdPrefix).to.equal(options.statsdPrefix);
+    expect(s.statsHost).to.equal(options.statsHost);
+    expect(s.statsPort).to.equal(options.statsPort);
+    expect(s.statsPrefix).to.equal(options.statsPrefix);
   });
 
   it("Build empty queue", () => {

--- a/test/stats/factory.test.js
+++ b/test/stats/factory.test.js
@@ -1,0 +1,46 @@
+import Factory from "../../stats/factory";
+import Promise from "bluebird";
+import chai from "chai";
+import chaiAsPromise from "chai-as-promised";
+
+import logger from "../../logger";
+
+// eat console logs
+logger.output = {
+  log() { },
+  error() { },
+  debug() { },
+  warn() { }
+};
+
+import _ from "lodash";
+
+chai.use(chaiAsPromise);
+
+const expect = chai.expect;
+const assert = chai.assert;
+
+describe("Factory", () => {
+  let options = {
+    "statsType": "influxdb",
+    "statsHost": "",
+    "statsPort": null,
+    "statsPrefix": "testdddtest.",
+    "statsDatabase": ""
+  };
+
+  it("Valid adaptor name", () => {
+    let adaptor = new Factory(options.statsType, options);
+
+    expect(adaptor).to.be.a("Object");
+  });
+
+  it("Invalid adaptor name", () => {
+    try {
+      let adaptor = new Factory("mongodb", options);
+
+    } catch (err) {
+      expect(err.message).to.equal("No such stats adaptor found in lib/stats/");
+    }
+  });
+});

--- a/test/supervisor.test.js
+++ b/test/supervisor.test.js
@@ -34,6 +34,14 @@ describe("Supervisor", () => {
 
         "restartCron": "*/2 * * * *"
       },
+      statsSwitch: false,
+      statsConfig: {
+        "statsType": "influxdb",
+        "statsHost": "",
+        "statsPort": null,
+        "statsPrefix": "testdddtest.",
+        "statsDatabase": ""
+      },
       restartCron: false
     });
 
@@ -63,6 +71,14 @@ describe("Supervisor", () => {
             "sharedTunnel": true,
 
             "restartCron": "*/2 * * * *"
+          },
+          statsSwitch: false,
+          statsConfig: {
+            "statsType": "influxdb",
+            "statsHost": "",
+            "statsPort": null,
+            "statsPrefix": "testdddtest.",
+            "statsDatabase": ""
           },
           restartCron: false
         });
@@ -102,6 +118,14 @@ describe("Supervisor", () => {
             "sharedTunnel": true,
 
             "restartCron": "*/2 * * * *"
+          },
+          statsSwitch: false,
+          statsConfig: {
+            "statsType": "influxdb",
+            "statsHost": "",
+            "statsPort": null,
+            "statsPrefix": "testdddtest.",
+            "statsDatabase": ""
           },
           restartCron: false
         });
@@ -191,5 +215,102 @@ describe("Supervisor", () => {
         .then(() => assert(false, "One of the tunnel succeeded in starting"))
         .catch(err => Promise.resolve());
     });
-  })
+  });
+
+  describe("Stats", () => {
+    it("Stats is enabled with valid adaptor", () => {
+      let s = new Supervisor({
+        tunnelAmount: 3,
+        tunnelConfig: {
+          "username": "fake_name",
+          "accessKey": "fake_key",
+          "verbose": false,
+          "proxy": null,
+          "tunnelIdentifier": "testfortest",
+          "waitTunnelShutdown": true,
+          "noRemoveCollidingTunnels": true,
+          "sharedTunnel": true,
+
+          "restartCron": "*/2 * * * *"
+        },
+        statsSwitch: true,
+        statsConfig: {
+          "statsType": "influxdb",
+          "statsHost": "",
+          "statsPort": null,
+          "statsPrefix": "testdddtest.",
+          "statsDatabase": ""
+        },
+        restartCron: false
+      });
+
+      assert(true, "Stats is enabled with valid adaptor");
+    });
+
+    it("Stats is enabled with invalid adaptor", () => {
+      try {
+        let s = new Supervisor({
+          tunnelAmount: 3,
+          tunnelConfig: {
+            "username": "fake_name",
+            "accessKey": "fake_key",
+            "verbose": false,
+            "proxy": null,
+            "tunnelIdentifier": "testfortest",
+            "waitTunnelShutdown": true,
+            "noRemoveCollidingTunnels": true,
+            "sharedTunnel": true,
+
+            "restartCron": "*/2 * * * *"
+          },
+          statsSwitch: true,
+          statsConfig: {
+            "statsType": "mongodb",
+            "statsHost": "",
+            "statsPort": null,
+            "statsPrefix": "testdddtest.",
+            "statsDatabase": ""
+          },
+          restartCron: false
+        });
+
+        assert(false, "Stats is enabled with invalid adaptor")
+      } catch (err) {
+        expect(err.message).to.equal("No such stats adaptor found in lib/stats/");
+      }
+    });
+
+    it("Stats is disabled with invalid adaptor", () => {
+      try {
+        let s = new Supervisor({
+          tunnelAmount: 3,
+          tunnelConfig: {
+            "username": "fake_name",
+            "accessKey": "fake_key",
+            "verbose": false,
+            "proxy": null,
+            "tunnelIdentifier": "testfortest",
+            "waitTunnelShutdown": true,
+            "noRemoveCollidingTunnels": true,
+            "sharedTunnel": true,
+
+            "restartCron": "*/2 * * * *"
+          },
+          statsSwitch: false,
+          statsConfig: {
+            "statsType": "mongodb",
+            "statsHost": "",
+            "statsPort": null,
+            "statsPrefix": "testdddtest.",
+            "statsDatabase": ""
+          },
+          restartCron: false
+        });
+
+        assert(true, "Stats is disabled with invalid adaptor")
+      } catch (err) {
+        assert(false, "Stats is enabled with invalid adaptor")
+      }
+    });
+  });
 });

--- a/test/tunnel.test.js
+++ b/test/tunnel.test.js
@@ -24,7 +24,7 @@ const assert = chai.assert;
 describe("Tunnel", () => {
   let sauceConnectLauncherMock = null;
   let saucelabsApiMock = null;
-  let statsDMock = { gauge(stat, data, tags) { } };
+  let statsMock = { gauge(stat, data, tags) { } };
   let statsQueue = {};
 
   let options = {
@@ -51,10 +51,10 @@ describe("Tunnel", () => {
 
     statsQueue = new StatsQueue({
       statsSwitch: true,
-      statsdHost: "some.where.local.org",
-      statsdPort: null,
-      statsdPrefix: "fake.",
-      statsD: statsDMock
+      statsHost: "some.where.local.org",
+      statsPort: null,
+      statsPrefix: "fake.",
+      stats: statsMock
     });
 
     saucelabsApiMock = { deleteTunnel(id, cb) { cb(null, "fake res") } };

--- a/test/tunnel.test.js
+++ b/test/tunnel.test.js
@@ -51,9 +51,11 @@ describe("Tunnel", () => {
 
     statsQueue = new StatsQueue({
       statsSwitch: true,
+      statsType: "influxdb",
       statsHost: "some.where.local.org",
       statsPort: null,
       statsPrefix: "fake.",
+      statsDatabase: "",
       stats: statsMock
     });
 


### PR DESCRIPTION
This PR contains following updates
1. Allow pushing data to different system/server by using/extending data adaptor with `--stats` on in command
2. Print out more information for debugging purpose with `--debug` on in command
3. More unit tests.