### PR TITLE
Remove references to waitTunnelShutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Since Crows-nest is coded in ES6, you need to compile before running it in your 
     "verbose": false,
     "proxy": null,
     "tunnelIdentifier": "",
-    "waitTunnelShutdown": true,
     "noRemoveCollidingTunnels": true,
     "sharedTunnel": true
   },

--- a/config.json
+++ b/config.json
@@ -5,7 +5,6 @@
     "verbose": false,
     "proxy": null,
     "tunnelIdentifier": "",
-    "waitTunnelShutdown": true,
     "noRemoveCollidingTunnels": true,
     "sharedTunnel": true
   },


### PR DESCRIPTION
--wait-tunnel-shutdown is removed as per https://wiki.saucelabs.com/pages/viewpage.action?pageId=48365781

SAUCE_CONNECT_VERSION 4.4.9 (latest)